### PR TITLE
🎨 IMPROVE: version git hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ buildNumber.properties
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
+.classpath
+.factorypath
+.project
+.settings

--- a/src/main/java/org/lorislab/maven/semver/release/maven/AbstractSemVerMojo.java
+++ b/src/main/java/org/lorislab/maven/semver/release/maven/AbstractSemVerMojo.java
@@ -105,10 +105,11 @@ abstract class AbstractSemVerMojo extends AbstractMojo {
      */
     Repository getGitRepository() throws IOException {
         FileRepositoryBuilder repositoryBuilder = new FileRepositoryBuilder();
-        return repositoryBuilder
-                .setGitDir(dotGitDirectory)
-                .readEnvironment() // scan environment GIT_* variables
-//                .findGitDir() // scan up the file system tree
+        if (dotGitDirectory.exists() && dotGitDirectory.isDirectory()) {
+            repositoryBuilder.setGitDir(dotGitDirectory);
+        }
+        return repositoryBuilder.readEnvironment() // scan environment GIT_* variables
+                // .findGitDir() // scan up the file system tree
                 .build();
     }
 
@@ -125,7 +126,8 @@ abstract class AbstractSemVerMojo extends AbstractMojo {
             // update parent in the project children
             try {
                 Map<String, Model> reactorModels = PomHelper.getReactorModels(project, getLog());
-                final SortedMap<String, Model> reactor = new TreeMap<String, Model>(new ReactorDepthComparator(reactorModels));
+                final SortedMap<String, Model> reactor = new TreeMap<String, Model>(
+                        new ReactorDepthComparator(reactorModels));
                 reactor.putAll(reactorModels);
 
                 changeVersions("", reactor, project.getGroupId(), project.getArtifactId(), newVersion);
@@ -135,8 +137,8 @@ abstract class AbstractSemVerMojo extends AbstractMojo {
         }
     }
 
-
-    private void changeVersions(String key, SortedMap<String, Model> reactor, String groupId, String artifactId, String newVersion) throws MojoExecutionException {
+    private void changeVersions(String key, SortedMap<String, Model> reactor, String groupId, String artifactId,
+            String newVersion) throws MojoExecutionException {
         // change the current pom version
         changeVersion(getFile(project, key), newVersion, PROJECT_VERSION_XPATH);
 

--- a/src/main/java/org/lorislab/maven/semver/release/maven/VersionGitHashMojo.java
+++ b/src/main/java/org/lorislab/maven/semver/release/maven/VersionGitHashMojo.java
@@ -49,15 +49,15 @@ public class VersionGitHashMojo extends AbstractSemVerMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         Version version = getVersion();
-        if (isSnapshot(version)) {
+        // if (isSnapshot(version)) {
 
-            // replace SNAPSHOT with git hash
-            String tmp = gitHash();
-            version = version.setPreReleaseVersion(tmp);
+        // replace SNAPSHOT with git hash
+        String tmp = gitHash();
+        version = version.setPreReleaseVersion(tmp);
 
-            // change project version
-            changeProjectVersion(version.toString());
-        }
+        // change project version
+        changeProjectVersion(version.toString());
+        // }
     }
 
     /**


### PR DESCRIPTION
- fix project.basedir when the .git directory is not where default looks
  for then read git environment var .
- for continuous delivery set the hash string version for non snapshot too.
- check if the default project.basedir exists and it is a directory
- remove check to be snapshot to apply git hash versioning